### PR TITLE
Apply `white-space: pre` onto the entire code snippet

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1328,14 +1328,11 @@ div.tip p:first-child {
 .docs .phpcode code {
     display: block;
     overflow-x: auto;
+    white-space: pre;
 }
 
 .docs .qandaentry dt .phpcode * {
     font-weight: normal;
-}
-
-.phpcode code span span {
-    white-space: pre;
 }
 
 /* }}} */


### PR DESCRIPTION
This is needed to correctly handle whitespace outside of a `<?php … ?>` portion.

see php/web-php@b7bccc4049ef4b70810fa159796133019674bdf8 see php/phd@01d6beb366bfb5e5b99bfdcc44393d8d1ee2d433 see php/doc-en#2648